### PR TITLE
Use only one spidertron body orientation in image

### DIFF
--- a/spidertron.css
+++ b/spidertron.css
@@ -87,8 +87,7 @@ SOFTWARE.
 
     width: 132px;
     height: 138px;
-    background-image: url(https://spidertron.alt-f4.blog/assets/torso/hr-spidertron-body.png);
-    background-position: -264px -414px;
+    background-image: url(https://spidertron.alt-f4.blog/assets-small/torso/hr-spidertron-body.png);
 
     z-index: 451;
 }


### PR DESCRIPTION
This will shrink the file down to 32KB from 1.3MB.